### PR TITLE
use sky.coflnet.com by default

### DIFF
--- a/src/main/java/de/torui/coflsky/CoflSky.java
+++ b/src/main/java/de/torui/coflsky/CoflSky.java
@@ -27,9 +27,9 @@ public class CoflSky
 
     
     public static final String[] webSocketURIPrefix = new String [] {
-        	"wss://sky-commands.coflnet.com/modsocket",
-            "wss://sky-mod.coflnet.com/modsocket",
-        	"ws://sky-commands.coflnet.com/modsocket",
+        	"wss://sky.coflnet.com/modsocket",
+        	"wss://sky-mod.coflnet.com/modsocket",
+        	"ws://sky.coflnet.com/modsocket",
         	"ws://sky-mod.coflnet.com/modsocket",
     };
     


### PR DESCRIPTION
sky.coflnet.com should be uses because it is loadbalanced