### PR TITLE
initial fix, needs testing!

### DIFF
--- a/src/main/java/de/torui/coflsky/CoflSkyCommand.java
+++ b/src/main/java/de/torui/coflsky/CoflSkyCommand.java
@@ -8,6 +8,7 @@ import java.util.List;
 import de.torui.coflsky.commands.Command;
 import de.torui.coflsky.commands.CommandType;
 import de.torui.coflsky.commands.JsonStringCommand;
+import de.torui.coflsky.commands.RawCommand;
 import de.torui.coflsky.minecraft_integration.CoflSessionManager;
 import de.torui.coflsky.minecraft_integration.CoflSessionManager.CoflSession;
 import de.torui.coflsky.network.QueryServerCommands;
@@ -156,10 +157,10 @@ public class CoflSkyCommand extends CommandBase {
 	public void CommandNotRecognized(String[] args, ICommandSender sender) {
 		String command = String.join(" ", Arrays.copyOfRange(args, 1, args.length));
 		
-		JsonStringCommand sc = new JsonStringCommand(args[0], WSClient.gson.toJson(command));
-		
+		//JsonStringCommand sc = new JsonStringCommand(args[0], WSClient.gson.toJson(command));
+		RawCommand rc = new RawCommand(args[0], WSClient.gson.toJson(command));
 		if(CoflSky.Wrapper.isRunning) {
-			CoflSky.Wrapper.SendMessage(sc);
+			CoflSky.Wrapper.SendMessage(rc);
 		} else {
 			sender.addChatMessage(new ChatComponentText("CoflSky not active. Server Commands are currently not available.").setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
 		}

--- a/src/main/java/de/torui/coflsky/commands/RawCommand.java
+++ b/src/main/java/de/torui/coflsky/commands/RawCommand.java
@@ -1,0 +1,33 @@
+package de.torui.coflsky.commands;
+
+import com.google.gson.annotations.SerializedName;
+
+public class RawCommand {
+	@SerializedName("type")
+	private String Type;
+	
+	@SerializedName("data")
+	private String Data;
+	
+	public RawCommand(String type, String data) {
+		this.Type = type;
+		this.Data=data;
+	}
+
+	public String getType() {
+		return Type;
+	}
+
+	public void setType(String type) {
+		Type = type;
+	}
+
+	public String getData() {
+		return Data;
+	}
+
+	public void setData(String data) {
+		Data = data;
+	}
+	
+}

--- a/src/main/java/de/torui/coflsky/network/WSClient.java
+++ b/src/main/java/de/torui/coflsky/network/WSClient.java
@@ -18,6 +18,7 @@ import de.torui.coflsky.CoflSky;
 import de.torui.coflsky.WSCommandHandler;
 import de.torui.coflsky.commands.Command;
 import de.torui.coflsky.commands.JsonStringCommand;
+import de.torui.coflsky.commands.RawCommand;
 
 public class WSClient extends WebSocketAdapter {
 
@@ -121,7 +122,15 @@ public class WSClient extends WebSocketAdapter {
 	}
 
 	public void SendCommand(Command cmd) {
-		String json = gson.toJson(cmd);
+		Send(cmd);
+	}
+
+	public void SendCommand(RawCommand cmd) {
+		Send(cmd);
+	}
+	
+	public void Send(Object obj) {
+		String json = gson.toJson(obj);
 		this.socket.sendText(json);
 	}
 		

--- a/src/main/java/de/torui/coflsky/network/WSClientWrapper.java
+++ b/src/main/java/de/torui/coflsky/network/WSClientWrapper.java
@@ -11,6 +11,7 @@ import com.neovisionaries.ws.client.WebSocketException;
 import de.torui.coflsky.CoflSky;
 import de.torui.coflsky.commands.Command;
 import de.torui.coflsky.commands.JsonStringCommand;
+import de.torui.coflsky.commands.RawCommand;
 import de.torui.coflsky.minecraft_integration.PlayerDataProvider;
 import net.minecraft.client.Minecraft;
 import net.minecraft.event.ClickEvent;
@@ -148,6 +149,13 @@ public class WSClientWrapper {
     	}
     }
     
+    public synchronized void SendMessage(RawCommand cmd){
+    	if(this.isRunning) {
+    		this.socket.SendCommand(cmd);
+    	} else {
+    		Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText("tried sending a callback to coflnet but failed. the connection must be closed."));
+    	}
+    }
     public synchronized void SendMessage(Command cmd){
     	if(this.isRunning) {
     		this.socket.SendCommand(cmd);


### PR DESCRIPTION
This should fix #41.
Can you test if this is now the desired behaviour @Ekwav?

you can use the build artifact to check it.

I could also add in that it logs an exception, when the commandtype is not in the known enum set to ensure there is no regression.