### PR TITLE
prevent hotkey from being spammed when held

### DIFF
--- a/src/main/java/de/torui/coflsky/WSCommandHandler.java
+++ b/src/main/java/de/torui/coflsky/WSCommandHandler.java
@@ -25,7 +25,6 @@ import net.minecraft.util.ChatStyle;
 import net.minecraft.util.IChatComponent;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.ClientCommandHandler;
-import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModContainer;
 
@@ -97,8 +96,8 @@ public class WSCommandHandler {
         Command<ChatMessageData[]> showCmd = new Command<ChatMessageData[]>(CommandType.ChatMessage, messages);
         ChatMessage(showCmd);
         flipHandler.fds.Insert(cmd.getData());
-        // trigger the keyevent to execute the event handler
-        CoflSky.Events.onKeyEvent(null);
+        // trigger the onAfterHotkeyPressed function to open the flip if the correct hotkey is currently still pressed
+        EventRegistry.onAfterKeyPressed();
     }
 
     private static void handleProxyRequest(ProxyRequest[] request) {
@@ -106,7 +105,6 @@ public class WSCommandHandler {
             proxyManager.handleRequestAsync(req);
         }
     }
-
 
     public static void cacheMods() {
         File modFolder = new File(Minecraft.getMinecraft().mcDataDir, "mods");

--- a/src/main/java/de/torui/coflsky/handlers/EventRegistry.java
+++ b/src/main/java/de/torui/coflsky/handlers/EventRegistry.java
@@ -58,19 +58,22 @@ public class EventRegistry {
         }
     }
 
-    public long LastClick = System.currentTimeMillis();
-    public boolean LastKeyboardState;
+    public static long LastClick = System.currentTimeMillis();
+    public static Boolean LastHotkeyState;
     private DescriptionHandler descriptionHandler;
 
     @SideOnly(Side.CLIENT)
     @SubscribeEvent(priority = EventPriority.NORMAL, receiveCanceled = true)
     public void onKeyEvent(KeyInputEvent event) {
 
-        if(Keyboard.getEventKeyState() == LastKeyboardState){
+        if (LastHotkeyState != null && Keyboard.getEventKeyState() == LastHotkeyState) {
             return;
         }
-        LastKeyboardState = Keyboard.getEventKeyState();
+        LastHotkeyState = Keyboard.getEventKeyState();
+        onAfterKeyPressed();
+    }
 
+    public static void onAfterKeyPressed() {
         if (CoflSky.keyBindings[0].isPressed()) {
             if (WSCommandHandler.lastOnClickEvent != null) {
                 FlipData f = WSCommandHandler.flipHandler.fds.GetLastFlip();

--- a/src/main/java/de/torui/coflsky/handlers/EventRegistry.java
+++ b/src/main/java/de/torui/coflsky/handlers/EventRegistry.java
@@ -38,6 +38,7 @@ import net.minecraftforge.fml.common.network.FMLNetworkEvent.ClientDisconnection
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
+import org.lwjgl.input.Keyboard;
 
 import static de.torui.coflsky.CoflSky.config;
 import static de.torui.coflsky.handlers.DescriptionHandler.*;
@@ -58,11 +59,17 @@ public class EventRegistry {
     }
 
     public long LastClick = System.currentTimeMillis();
+    public boolean LastKeyboardState;
     private DescriptionHandler descriptionHandler;
 
     @SideOnly(Side.CLIENT)
     @SubscribeEvent(priority = EventPriority.NORMAL, receiveCanceled = true)
     public void onKeyEvent(KeyInputEvent event) {
+
+        if(Keyboard.getEventKeyState() == LastKeyboardState){
+            return;
+        }
+        LastKeyboardState = Keyboard.getEventKeyState();
 
         if (CoflSky.keyBindings[0].isPressed()) {
             if (WSCommandHandler.lastOnClickEvent != null) {


### PR DESCRIPTION
fixes #108 

@Ekwav  This fix prevents the hotkey logic from being spammed when the button is held.
A) If this is implemented the message when no best flip was found should be changed, as it currently recommends you to keep holding the button, which wouldn't do anything anymore.
B) This might be disliked as the button now has to be spammed by users instead of being conveniently held down.

Wouldn't it be better to just increase the delay between each execution? (Currently the delay is only applied after a flip  has been successfully found, I think that also might be an oversight)